### PR TITLE
Feature/fix charge time issue

### DIFF
--- a/DarkZagreus/Weapons/RushWeapon.lua
+++ b/DarkZagreus/Weapons/RushWeapon.lua
@@ -14,8 +14,8 @@ WeaponData.DarkRush =
         AIAngleTowardsPlayerWhileFiring = true,
         AITrackTargetDuringCharge = true,
         AIMoveWithinRangeTimeout = 1.0,
-        FireDuration = 0.2,
-        -- WaitUntilProjectileDeath = true
+        -- FireDuration = 0.2,
+        WaitUntilProjectileDeath = true
     },
 
     SimSlowBlur =

--- a/DarkZagreus/Weapons/Spears/AspectofAchilles.lua
+++ b/DarkZagreus/Weapons/Spears/AspectofAchilles.lua
@@ -6,7 +6,7 @@ WeaponData.DarkAchillesSpear =
 
 		AIData =
 		{
-			AttackDistance = 250,
+			AttackDistance = 400,
 			AIAngleTowardsPlayerWhileFiring = true,
 			AITrackTargetDuringCharge = true,
 			AIMoveWithinRangeTimeout = 1.0,
@@ -69,7 +69,7 @@ WeaponData.DarkAchillesSpear2 =
 			AITrackTargetDuringCharge = true,
 			SkipMovement = true,
 			ChainedWeapon = "DarkAchillesSpear3",
-			FireDuration = 0.3,
+			FireDuration = 0.05,
 			PostFireChargeStages = 
 			{
 				{ ChargeWeapon = "DarkAchillesSpearSpin", Threshold = 0.6 },
@@ -112,7 +112,7 @@ WeaponData.DarkAchillesSpear3 =
 			SkipMovement = true,
 			AIAngleTowardsPlayerWhileFiring = true,
 			AITrackTargetDuringCharge = true,
-			FireDuration = 0.3,
+			FireDuration = 0.05,
 			PostFireChargeStages = 
 			{
 				{ ChargeWeapon = "DarkSpearSpin", Threshold = 0.6 },

--- a/DarkZagreus/Weapons/Spears/AspectofGuanYu.lua
+++ b/DarkZagreus/Weapons/Spears/AspectofGuanYu.lua
@@ -9,7 +9,7 @@ WeaponData.DarkGuanYuSpear =
 
 		AIData =
 		{
-			AttackDistance = 300,
+			AttackDistance = 400,
 			AIAngleTowardsPlayerWhileFiring = true,
 			AITrackTargetDuringCharge = true,
 			AIMoveWithinRangeTimeout = 1.0,
@@ -75,7 +75,7 @@ WeaponData.DarkGuanYuSpear2 =
 			AITrackTargetDuringCharge = true,
 			SkipMovement = true,
 			ChainedWeapon = "DarkGuanYuSpear3",
-			FireDuration = 0.3,
+			FireDuration = 0.05,
 			PostFireChargeStages = 
 			{
 				{ ChargeWeapon = "DarkGuanYuSpearSpin", Threshold = 0.6 },
@@ -117,7 +117,7 @@ WeaponData.DarkGuanYuSpear3 =
 			SkipMovement = true,
 			AIAngleTowardsPlayerWhileFiring = true,
 			AITrackTargetDuringCharge = true,
-			FireDuration = 0.3,
+			FireDuration = 0.05,
 			PostFireChargeStages = 
 			{
 				{ ChargeWeapon = "DarkGuanYuSpearSpin", Threshold = 0.6 },

--- a/DarkZagreus/Weapons/Spears/AspectofHades.lua
+++ b/DarkZagreus/Weapons/Spears/AspectofHades.lua
@@ -9,7 +9,7 @@ WeaponData.DarkHadesSpear =
 
 		AIData =
 		{
-			AttackDistance = 300,
+			AttackDistance = 400,
 			AIAngleTowardsPlayerWhileFiring = true,
 			AITrackTargetDuringCharge = true,
 			ChainedWeapon = "DarkHadesSpear2",
@@ -70,7 +70,7 @@ WeaponData.DarkHadesSpear2 =
 			AITrackTargetDuringCharge = true,
 			SkipMovement = true,
 			ChainedWeapon = "DarkHadesSpear3",
-			FireDuration = 0.3,
+			FireDuration = 0.05,
 			PostFireChargeStages = 
 			{
 				{ ChargeWeapon = "DarkHadesSpearSpin2", Threshold = 0.75 },
@@ -112,7 +112,7 @@ WeaponData.DarkHadesSpear3 =
 			SkipMovement = true,
 			AIAngleTowardsPlayerWhileFiring = true,
 			AITrackTargetDuringCharge = true,
-			FireDuration = 0.4,
+			FireDuration = 0.05,
 			PostFireChargeStages = 
 			{
 				{ ChargeWeapon = "DarkHadesSpear2", Threshold = 0.75 },

--- a/DarkZagreus/Weapons/Spears/SpearWeapon.lua
+++ b/DarkZagreus/Weapons/Spears/SpearWeapon.lua
@@ -7,7 +7,7 @@ WeaponData.DarkSpear =
 
 		AIData =
 		{
-			AttackDistance = 200,
+			AttackDistance = 300,
 			AIAngleTowardsPlayerWhileFiring = true,
 			AITrackTargetDuringCharge = true,
 			ChainedWeapon = "DarkSpear2",
@@ -69,7 +69,7 @@ WeaponData.DarkSpear2 =
 			AITrackTargetDuringCharge = true,
 			SkipMovement = true,
 			ChainedWeapon = "DarkSpear3",
-			FireDuration = 0.3,
+			FireDuration = 0.05,
 			PostFireChargeStages = 
 			{
 				{ ChargeWeapon = "DarkSpearSpin", Threshold = 0.6 },
@@ -112,7 +112,7 @@ WeaponData.DarkSpear3 =
 			SkipMovement = true,
 			AIAngleTowardsPlayerWhileFiring = true,
 			AITrackTargetDuringCharge = true,
-			FireDuration = 0.3,
+			FireDuration = 0.05,
 			PostFireChargeStages = 
 			{
 				{ ChargeWeapon = "DarkSpearSpin", Threshold = 0.6 },

--- a/Scripts/EnemyAI.lua
+++ b/Scripts/EnemyAI.lua
@@ -28,7 +28,7 @@ function DarkZagreusAI( enemy, currentRun )
 	end
 end
 
-function DZAIDoMove(enemy, currentRun, targetId, weaponAIData, actionData)
+function DZAIDoMove(enemy, currentRun, targetId, weaponAIData, actionData, percentageCharged)
     if weaponAIData == nil then
         weaponAIData = enemy
     end
@@ -42,9 +42,8 @@ function DZAIDoMove(enemy, currentRun, targetId, weaponAIData, actionData)
     end
 
     if weaponAIData.IsAttackDistanceBasedOnCharge then
-        local chargeTime = actionData.ChargeTime
         local rangeMax = weaponAIData.Range * weaponAIData.ChargeRangeMultiplier
-        attackDistance = chargeTime * rangeMax
+        attackDistance = percentageCharged * rangeMax
     end
 
     AngleTowardTarget({ Id = enemy.ObjectId, DestinationId = targetId })
@@ -138,17 +137,13 @@ function DZAIGetCurrentState(enemy)
 end
 
 function DZAIMakeRandomActionData(state)
-    local r = math.random()
-    local chargeTime = 0.0
-
-    chargeTime = r
 
     return {
         DashToward = 0.2, -- 0.2
         Attack = 0.5, -- 0.5
         SpecialAttack = 0.2, -- 0.2
         DashAway = 0.1,
-        ChargeTime = chargeTime
+        ChargeAttack = 0.0
     }
 end
 
@@ -161,11 +156,9 @@ function DZAIMakeActionData(state, lastActions)
     local lastAction = lastActions[#lastActions]
 
     if lastAction == nil then
-       lastAction = 
-       {
-        Action = 0,
-        ChargeTime = 0.0
-       } 
+       lastAction = {
+        Action = 0
+       }
     end
 
     DZTemp.Model:activate({
@@ -174,27 +167,27 @@ function DZAIMakeActionData(state, lastActions)
         (lastAction.Action == 1) and 1 or 0, -- if last action is attack
         (lastAction.Action == 2) and 1 or 0, -- if last action is special attack,
         (lastAction.Action == 3) and 1 or 0, -- if last action is dash away
-        lastAction.ChargeTime }
-    )
+        (lastAction.Action == 4) and 1 or 0, -- if last action is charged attack, which appears in spear and shield  
+    })
 
     local dashTowardProb = DZTemp.Model[4].cells[1].signal
     local attackProb = DZTemp.Model[4].cells[2].signal
     local specialProb = DZTemp.Model[4].cells[3].signal
     local dashAwayProb = DZTemp.Model[4].cells[4].signal
-    local chargeTime = DZTemp.Model[4].cells[5].signal
+    local chargeAttackProb = DZTemp.Model[4].cells[5].signal
 
     DZDebugPrintString(string.format("dash toward prob | %.3f", dashTowardProb))
     DZDebugPrintString(string.format("attack prob | %.3f", attackProb))
     DZDebugPrintString(string.format("special prob | %.3f", specialProb))
     DZDebugPrintString(string.format("dash away prob | %.3f", dashAwayProb))
-    DZDebugPrintString(string.format("charge time | %.3f", chargeTime))
+    DZDebugPrintString(string.format("charged attack prob | %.3f", chargeAttackProb))
 
     return {    
         DashToward = dashTowardProb,
         Attack = attackProb,
         SpecialAttack = specialProb,
         DashAway = dashAwayProb,
-        ChargeTime = chargeTime
+        ChargeAttack = chargeAttackProb
     }
 end
 

--- a/Scripts/EnemyShieldAI.lua
+++ b/Scripts/EnemyShieldAI.lua
@@ -13,10 +13,10 @@ function DZAIDoShieldAILoop(enemy, currentRun, targetId)
     enemy.WeaponName = DZAISelectShieldWeapon(enemy, actionData)
 
     if enemy.WeaponName == nil then
-        return false
+        return true -- continue to next action
     end
-
     -- DebugAssert({ Condition = enemy.WeaponName ~= nil, Text = "Enemy has no weapon!" })
+    
     table.insert(enemy.WeaponHistory, enemy.WeaponName)
 
 	local weaponAIData = GetWeaponAIData(enemy)

--- a/Scripts/EnemyShieldAI.lua
+++ b/Scripts/EnemyShieldAI.lua
@@ -224,8 +224,25 @@ function DZAISelectShieldWeapon(enemy, actionData)
         return enemy.WeaponName
     end
 
+    if r < actionData.Attack + actionData.ChargeAttack then
+
+        enemy.DZ.TempAction = 4
+
+        -- if the last action is dash, do dash attack
+        if (lastAction.Action == 0 or lastAction.Action == 3) and _worldTime - enemy.DZ.LastActionTime < 0.3 then
+            enemy.WeaponName = enemy.DashAttackWeapon
+            enemy.ChainedWeapon = nil
+            return enemy.WeaponName
+        end
+
+        -- or just do a regular attack
+        enemy.WeaponName = enemy.PrimaryWeapon
+        enemy.ChainedWeapon = nil
+        return enemy.WeaponName
+    end
+
     -- use special attack
-    if r < actionData.Attack + actionData.SpecialAttack then
+    if r < actionData.Attack + actionData.ChargeAttack + actionData.SpecialAttack then
         enemy.DZ.TempAction = 2
         enemy.WeaponName = enemy.SpecialAttackWeapon
         enemy.ChainedWeapon = nil
@@ -233,14 +250,14 @@ function DZAISelectShieldWeapon(enemy, actionData)
     end
 
     -- use dash
-    if r < actionData.Attack + actionData.SpecialAttack + actionData.DashToward then
+    if r < actionData.Attack + actionData.ChargeAttack + actionData.SpecialAttack + actionData.DashToward then
         enemy.DZ.TempAction = 0
         enemy.WeaponName = enemy.DashWeapon
         enemy.ChainedWeapon = nil
         return enemy.WeaponName
     end
 
-    if r < actionData.Attack + actionData.SpecialAttack + actionData.DashToward + actionData.DashAway then
+    if r < actionData.Attack + actionData.ChargeAttack + actionData.SpecialAttack + actionData.DashToward + actionData.DashAway then
         enemy.DZ.TempAction = 3
         enemy.WeaponName = enemy.DashWeapon
         enemy.ChainedWeapon = nil
@@ -269,5 +286,5 @@ function DZAIMakeShieldChargeTime(action)
     end
 
     -- else, like charge special attack
-    return math.random(0.3, 1.0)
+    return 0.0
 end

--- a/Scripts/EnemySpearAI.lua
+++ b/Scripts/EnemySpearAI.lua
@@ -13,7 +13,12 @@ function DZAIDoSpearAILoop(enemy, currentRun, targetId)
 
     -- select a weapon to use if not exist
     enemy.WeaponName = DZAISelectSpearWeapon(enemy, actionData)
-    DebugAssert({ Condition = enemy.WeaponName ~= nil, Text = "Enemy has no weapon!" })
+
+        if enemy.WeaponName == nil then
+        return true -- continue to next action
+    end
+    -- DebugAssert({ Condition = enemy.WeaponName ~= nil, Text = "Enemy has no weapon!" })
+    
     table.insert(enemy.WeaponHistory, enemy.WeaponName)
 
 	local weaponAIData = GetWeaponAIData(enemy)

--- a/Scripts/EnemySpearAI.lua
+++ b/Scripts/EnemySpearAI.lua
@@ -18,7 +18,7 @@ function DZAIDoSpearAILoop(enemy, currentRun, targetId)
         return true -- continue to next action
     end
     -- DebugAssert({ Condition = enemy.WeaponName ~= nil, Text = "Enemy has no weapon!" })
-    
+
     table.insert(enemy.WeaponHistory, enemy.WeaponName)
 
 	local weaponAIData = GetWeaponAIData(enemy)
@@ -35,10 +35,12 @@ function DZAIDoSpearAILoop(enemy, currentRun, targetId)
 
     -- if there is a target
     if targetId ~= nil and targetId ~= 0 then
+
+        local percentageCharged = DZAIMakeSpearChargeTime(enemy.DZ.TempAction)
         
         -- Movement
         if not weaponAIData.SkipMovement then
-			local didTimeout = DZAIDoMove( enemy, currentRun, targetId, weaponAIData, actionData)
+			local didTimeout = DZAIDoMove( enemy, currentRun, targetId, weaponAIData, actionData, percentageCharged)
 
 			if didTimeout and weaponAIData.SkipAttackAfterMoveTimeout then
 				return true
@@ -49,7 +51,7 @@ function DZAIDoSpearAILoop(enemy, currentRun, targetId)
 		local attackSuccess = false
 
         while not attackSuccess do
-            attackSuccess = DZAIDoSpearAttackOnce( enemy, currentRun, targetId, weaponAIData, actionData )
+            attackSuccess = DZAIDoSpearAttackOnce( enemy, currentRun, targetId, weaponAIData, actionData, percentageCharged)
 
             if not attackSuccess then
 				enemy.AINotifyName = "CanAttack"..enemy.ObjectId
@@ -62,7 +64,7 @@ function DZAIDoSpearAILoop(enemy, currentRun, targetId)
     return true
 end
 
-function DZAIDoSpearAttackOnce(enemy, currentRun, targetId, weaponAIData, actionData)
+function DZAIDoSpearAttackOnce(enemy, currentRun, targetId, weaponAIData, actionData, percentageCharged)
     if targetId == nil then
         targetId = currentRun.Hero.ObjectId
     end
@@ -106,18 +108,18 @@ function DZAIDoSpearAttackOnce(enemy, currentRun, targetId, weaponAIData, action
 		return false
 	end
 
-    if not DZAIFireSpearWeapon( enemy, weaponAIData, currentRun, targetId, actionData ) then
+    if not DZAIFireSpearWeapon( enemy, weaponAIData, currentRun, targetId, actionData, percentageCharged) then
         return false
     end
 
     return true
 end
 
-function DZAIFireSpearWeapon(enemy, weaponAIData, currentRun, targetId, actionData)
+function DZAIFireSpearWeapon(enemy, weaponAIData, currentRun, targetId, actionData, percentageCharged)
     local chargeTime = 0.0
 
     if weaponAIData.PostFireChargeStages ~= nil then
-        chargeTime = actionData.ChargeTime * weaponAIData.MaxChargeTime
+        chargeTime = percentageCharged * weaponAIData.MaxChargeTime
         DebugPrintf({ Text = "Set chargeTime to " .. chargeTime})
     end
 
@@ -147,7 +149,7 @@ function DZAIFireSpearWeapon(enemy, weaponAIData, currentRun, targetId, actionDa
     -- Fire
     
     if weaponAIData.IsRangeBasedOnCharge then
-        DZAIDoChargeDistanceFire(enemy, weaponAIData, targetId, actionData.ChargeTime)
+        DZAIDoChargeDistanceFire(enemy, weaponAIData, targetId, percentageCharged)
     else
         DZAIDoRegularFire(enemy, weaponAIData, targetId)
     end
@@ -278,8 +280,33 @@ function DZAISelectSpearWeapon(enemy, actionData)
         return enemy.WeaponName
     end
 
+    -- use charge attack with primary attack weapon
+    if r < actionData.Attack + actionData.ChargeAttack then
+    
+        if enemy.ShouldReturnSpearAfterThrow and enemy.IsSpearThrown then
+            enemy.DZ.TempAction = 2
+            enemy.WeaponName = enemy.SpecialAttackWeaponReturn
+            enemy.ChainedWeapon = nil
+            return enemy.WeaponName
+        end
+
+        enemy.DZ.TempAction = 4
+
+        -- if the last action is dash, do dash attack
+        if (lastAction.Action == 0 or lastAction.Action == 3) and _worldTime - enemy.DZ.LastActionTime < 0.3 then
+            enemy.WeaponName = enemy.DashAttackWeapon
+            enemy.ChainedWeapon = nil
+            return enemy.WeaponName
+        end
+
+        -- or just do a regular attack
+        enemy.WeaponName = enemy.PrimaryWeapon
+        enemy.ChainedWeapon = nil
+        return enemy.WeaponName
+    end
+
     -- use special attack
-    if r < actionData.Attack + actionData.SpecialAttack then
+    if r < actionData.Attack + actionData.ChargeAttack + actionData.SpecialAttack then
         enemy.DZ.TempAction = 2
         if enemy.ShouldReturnSpearAfterThrow and enemy.IsSpearThrown then
 
@@ -300,14 +327,14 @@ function DZAISelectSpearWeapon(enemy, actionData)
     end
 
     -- use dash
-    if r < actionData.Attack + actionData.SpecialAttack + actionData.DashToward then
+    if r < actionData.Attack + actionData.ChargeAttack + actionData.SpecialAttack + actionData.DashToward then
         enemy.DZ.TempAction = 0
         enemy.WeaponName = enemy.DashWeapon
         enemy.ChainedWeapon = nil
         return enemy.WeaponName
     end
 
-    if r < actionData.Attack + actionData.SpecialAttack + actionData.DashToward + actionData.DashAway then
+    if r < actionData.Attack + actionData.ChargeAttack + actionData.SpecialAttack + actionData.DashToward + actionData.DashAway then
         enemy.DZ.TempAction = 3
         enemy.WeaponName = enemy.DashWeapon
         enemy.ChainedWeapon = nil
@@ -317,4 +344,26 @@ function DZAISelectSpearWeapon(enemy, actionData)
 
     enemy.WeaponName = nil
     return nil
+end
+
+-- logic for deciding the charge time
+function DZAIMakeSpearChargeTime(action)
+
+    if action == 4 then -- charge attack
+        local r = math.random()
+
+        -- higer chance to do small charge, low chance do full charge
+        if r < 0.7 then
+            return 0.33 + math.random() * 0.33
+        elseif r < 0.9 then
+            return 0.66 + math.random() * 0.22
+        else
+            return 0.88 + math.random() * 0.12
+        end
+    elseif action == 2 then -- spcial attack
+        return math.random(0.3, 1.0)
+    end
+
+    -- else, like charge special attack
+    return 0.0
 end

--- a/Scripts/EnemySwordAI.lua
+++ b/Scripts/EnemySwordAI.lua
@@ -10,7 +10,11 @@ function DZAIDoSwordAILoop(enemy, currentRun, targetId)
 
     -- select a weapon to use if not exist
     enemy.WeaponName = DZAISelectSwordWeapon(enemy, actionData)
-    DebugAssert({ Condition = enemy.WeaponName ~= nil, Text = "Enemy has no weapon!" })
+
+    if enemy.WeaponName == nil then
+        return true -- continue to next action
+    end
+    -- DebugAssert({ Condition = enemy.WeaponName ~= nil, Text = "Enemy has no weapon!" })
     table.insert(enemy.WeaponHistory, enemy.WeaponName)
 
 	local weaponAIData = GetWeaponAIData(enemy)
@@ -158,7 +162,9 @@ end
 
 function DZAISelectSwordWeapon(enemy, actionData)
     local total = 
-        actionData.Attack + actionData.SpecialAttack + actionData.DashToward + actionData.DashAway
+        actionData.Attack + actionData.SpecialAttack 
+        + actionData.DashToward + actionData.DashAway
+        + actionData.ChargeAttack
     local r = math.random() * total
     
     enemy.DZ.TempAction = 0
@@ -167,7 +173,8 @@ function DZAISelectSwordWeapon(enemy, actionData)
     local lastActionTime = enemy.DZ.LastActionTime
 
     -- use attack weapon
-    if r < actionData.Attack then
+    -- I'll treat attack and charge attack the same in this domain
+    if r < actionData.Attack + actionData.ChargeAttack then
 
         enemy.DZ.TempAction = 1
 
@@ -196,7 +203,7 @@ function DZAISelectSwordWeapon(enemy, actionData)
     end
 
     -- use special attack
-    if r < actionData.Attack + actionData.SpecialAttack then
+    if r < actionData.Attack + actionData.ChargeAttack + actionData.SpecialAttack then
         enemy.DZ.TempAction = 2
         enemy.WeaponName = enemy.SpecialAttackWeapon
         enemy.ChainedWeapon = nil
@@ -204,14 +211,14 @@ function DZAISelectSwordWeapon(enemy, actionData)
     end
 
     -- use dash
-    if r < actionData.Attack + actionData.SpecialAttack + actionData.DashToward then
+    if r < actionData.Attack + actionData.ChargeAttack + actionData.SpecialAttack + actionData.DashToward then
         enemy.DZ.TempAction = 0
         enemy.WeaponName = enemy.DashWeapon
         enemy.ChainedWeapon = nil
         return enemy.WeaponName
     end
 
-    if r < actionData.Attack + actionData.SpecialAttack + actionData.DashToward + actionData.DashAway then
+    if r < actionData.Attack + actionData.ChargeAttack + actionData.SpecialAttack + actionData.DashToward + actionData.DashAway then
         enemy.DZ.TempAction = 3
         enemy.WeaponName = enemy.DashWeapon
         enemy.ChainedWeapon = nil

--- a/Scripts/EnemySwordAI.lua
+++ b/Scripts/EnemySwordAI.lua
@@ -34,7 +34,7 @@ function DZAIDoSwordAILoop(enemy, currentRun, targetId)
         
         -- Movement
         if not weaponAIData.SkipMovement then
-			local didTimeout = DZAIDoMove( enemy, currentRun, targetId, weaponAIData, actionData)
+			local didTimeout = DZAIDoMove( enemy, currentRun, targetId, weaponAIData, actionData, 0)
 
 			if didTimeout and weaponAIData.SkipAttackAfterMoveTimeout then
 				return true
@@ -150,7 +150,7 @@ function DZAIFireSwordWeapon(enemy, weaponAIData, currentRun, targetId, actionDa
 
     enemy.DZ.LastActionTime = _worldTime
     -- save both which action is used and the charge time
-    DZAIEnqueueLastAction(enemy, { Action = enemy.DZ.TempAction, ChargeTime = actionData.ChargeTime })
+    DZAIEnqueueLastAction(enemy, { Action = enemy.DZ.TempAction })
 
     if ReachedAIStageEnd(enemy) or currentRun.CurrentRoom.InStageTransition then
 		weaponAIData.ForcedEarlyExit = true

--- a/Scripts/RecordActionScripts.lua
+++ b/Scripts/RecordActionScripts.lua
@@ -1,16 +1,17 @@
 if not DarkZagreus.Config.Enabled then return end
  
 -- sword weapon
-OnWeaponCharging { "SwordWeapon SwordWeapon2 SwordWeapon3 SwordWeaponDash",
-    function(triggerArgs)
-        if not DZCheckCanRecord() then
-            return false
-        end
+-- charging is deprecated in data version v5
+-- OnWeaponCharging { "SwordWeapon SwordWeapon2 SwordWeapon3 SwordWeaponDash",
+--     function(triggerArgs)
+--         if not DZCheckCanRecord() then
+--             return false
+--         end
         
-        DZTemp.ChargeWeapon = "Attack"
-        DZTemp.StartChargingTime = _worldTime
-    end 
-}
+--         -- DZTemp.ChargeWeapon = "Attack"
+--         -- DZTemp.StartChargingTime = _worldTime
+--     end 
+-- }
 
 OnWeaponFired{ "SwordWeapon SwordWeapon2 SwordWeapon3 SwordWeaponDash",
     function( triggerArgs )
@@ -18,27 +19,27 @@ OnWeaponFired{ "SwordWeapon SwordWeapon2 SwordWeapon3 SwordWeaponDash",
             return false
         end
 
-        local duration = 0.0
+        -- local duration = 0.0
         
-        if DZTemp.ChargeWeapon == "Attack" then
-            duration = _worldTime - DZTemp.StartChargingTime 
-        end
+        -- if DZTemp.ChargeWeapon == "Attack" then
+        --     duration = _worldTime - DZTemp.StartChargingTime 
+        -- end
 
         -- DebugPrint({ Text = "Attack" })
-        DZPushPendingRecord(DZGetCurrentState(), DZMakeActionData(1, duration, 1))
+        DZPushPendingRecord(DZGetCurrentState(), DZMakeActionData(1))
     end
 }
 
-OnWeaponCharging { "SwordParry",
-    function(triggerArgs)
-        if not DZCheckCanRecord() then
-            return false
-        end
+-- OnWeaponCharging { "SwordParry",
+--     function(triggerArgs)
+--         if not DZCheckCanRecord() then
+--             return false
+--         end
         
-        DZTemp.ChargeWeapon = "SpecialAttack"
-        DZTemp.StartChargingTime = _worldTime
-    end 
-}
+--         -- DZTemp.ChargeWeapon = "SpecialAttack"
+--         -- DZTemp.StartChargingTime = _worldTime
+--     end 
+-- }
 
 OnWeaponFired{ "SwordParry",
     function( triggerArgs )
@@ -46,54 +47,18 @@ OnWeaponFired{ "SwordParry",
             return false
         end
 
-        local duration = 0.0
-
-        if DZTemp.ChargeWeapon == "SpecialAttack" then
-            duration = _worldTime - DZTemp.StartChargingTime 
-        end
-
-        -- DebugPrint({ Text = "SpecialAttack" })
-        DZPushPendingRecord(DZGetCurrentState(), DZMakeActionData(2, duration, 1))
+        DZPushPendingRecord(DZGetCurrentState(), DZMakeActionData(2))
     end
 }
 
 -- bow
-OnWeaponCharging { "BowWeapon BowWeaponDash",
-    function(triggerArgs)
-        if not DZCheckCanRecord() then
-            return false
-        end
-
-        DZTemp.ChargeWeapon = "Attack"
-        DZTemp.StartChargingTime = _worldTime
-    end 
-}
-
 OnWeaponFired { "BowWeapon BowWeaponDash",
     function(triggerArgs)
         if not DZCheckCanRecord() then
             return false
         end
         
-        local duration = 0.0
-
-        if DZTemp.ChargeWeapon == "Attack" then
-            duration = _worldTime - DZTemp.StartChargingTime 
-        end
-        -- DebugPrint({ Text = "ChargeDuration: " .. duration })
-        -- DebugPrint({ Text = "Attack" })
-        DZPushPendingRecord(DZGetCurrentState(), DZMakeActionData(1, duration, 1))
-    end 
-}
-
-OnWeaponCharging { "BowSplitShot",
-    function(triggerArgs)
-        if not DZCheckCanRecord() then
-            return false
-        end
-        
-        DZTemp.ChargeWeapon = "SpecialAttack"
-        DZTemp.StartChargingTime = _worldTime
+        DZPushPendingRecord(DZGetCurrentState(), DZMakeActionData(1))
     end 
 }
 
@@ -103,30 +68,12 @@ OnWeaponFired{ "BowSplitShot",
             return false
         end
 
-        local duration = 0.0
-
-        if DZTemp.ChargeWeapon == "SpecialAttack" then
-            duration = _worldTime - DZTemp.StartChargingTime 
-        end
-
         -- DebugPrint({ Text = "SpecialAttack" })
-        DZPushPendingRecord(DZGetCurrentState(), DZMakeActionData(2, duration, 1))
+        DZPushPendingRecord(DZGetCurrentState(), DZMakeActionData(2))
     end
 }
 
 -- spear
-
-OnWeaponCharging { "SpearWeapon SpearWeapon2 SpearWeapon3 SpearWeaponDash",
-    function(triggerArgs)
-        if not DZCheckCanRecord() then
-            return false
-        end
-
-        DZTemp.ChargeWeapon = "Attack"
-        DZTemp.StartChargingTime = _worldTime
-    end 
-}
-
 -- TODO: not sure if i can catch Flurry Jab
 OnWeaponFired { "SpearWeapon SpearWeapon2 SpearWeapon3 SpearWeaponDash",
     function(triggerArgs)
@@ -134,12 +81,7 @@ OnWeaponFired { "SpearWeapon SpearWeapon2 SpearWeapon3 SpearWeaponDash",
             return false
         end
 
-        local duration = 0.0
-        if DZTemp.ChargeWeapon == "Attack" then
-            duration = _worldTime - DZTemp.StartChargingTime 
-        end
-
-        DZPushPendingRecord(DZGetCurrentState(), DZMakeActionData(1, duration, 1))
+        DZPushPendingRecord(DZGetCurrentState(), DZMakeActionData(1))
     end 
 }
 
@@ -149,12 +91,7 @@ OnWeaponFired { "SpearWeaponSpin SpearWeaponSpin2 SpearWeaponSpin3",
             return false
         end
 
-        local duration = _worldTime - DZTemp.StartChargingTime
-        if DZTemp.ChargeWeapon == "Attack" then
-            duration = _worldTime - DZTemp.StartChargingTime 
-        end
-
-        DZOverridePendingRecord(DZGetCurrentState(), DZMakeActionData(1, duration, 1.6))     
+        DZOverridePendingRecord(DZGetCurrentState(), DZMakeActionData(4))     
     end 
 }
 
@@ -164,20 +101,8 @@ OnWeaponFired { "SpearWeaponThrowReturn",
             return false
         end
 
-        -- DebugPrint({ Text = "SpearWeaponThrowReturn" })
-        DZPushPendingRecord(DZGetCurrentState(), DZMakeActionData(2, 0, 1))
+        DZPushPendingRecord(DZGetCurrentState(), DZMakeActionData(2))
     end
-}
-
-OnWeaponCharging { "SpearWeaponThrow",
-    function(triggerArgs)
-        if not DZCheckCanRecord() then
-            return false
-        end
-
-        DZTemp.ChargeWeapon = "SpecialAttack"
-        DZTemp.StartChargingTime = _worldTime
-    end 
 }
 
 OnWeaponFired { "SpearWeaponThrow",
@@ -185,14 +110,8 @@ OnWeaponFired { "SpearWeaponThrow",
         if not DZCheckCanRecord() then
             return false
         end
-
-        local duration = 0.0
-
-        if DZTemp.ChargeWeapon == "SpecialAttack" then
-            duration = _worldTime - DZTemp.StartChargingTime 
-        end
         
-        DZPushPendingRecord(DZGetCurrentState(), DZMakeActionData(2, duration, 0.3)) 
+        DZPushPendingRecord(DZGetCurrentState(), DZMakeActionData(2)) 
     end 
 }
 
@@ -202,37 +121,19 @@ OnWeaponFired{ "SpearRushWeapon",
             return false
         end
 
-        -- DebugPrint({ Text = "SpearRushWeapon" })
-        DZPushPendingRecord(DZGetCurrentState(), DZMakeActionData(2, 0, 1))
-        -- LogRecord(DZGetCurrentState(), DZMakeActionData(2, 0, 1))
+        DZPushPendingRecord(DZGetCurrentState(), DZMakeActionData(2))
     end
 }
 
 -- shield
 -- TODO: handle Pulverizing Blow
-OnWeaponCharging { "ShieldWeapon ShieldWeaponDash",
-    function(triggerArgs)
-        if not DZCheckCanRecord() then
-            return false
-        end
-
-        DZTemp.ChargeWeapon = "Attack"
-        DZTemp.StartChargingTime = _worldTime
-    end 
-}
-
 OnWeaponFired { "ShieldWeapon ShieldWeaponDash",
     function(triggerArgs)
         if not DZCheckCanRecord() then
             return false
         end
 
-        local duration = 0.0
-        if DZTemp.ChargeWeapon == "Attack" then
-            duration = _worldTime - DZTemp.StartChargingTime 
-        end
-
-        DZPushPendingRecord(DZGetCurrentState(), DZMakeActionData(1, duration, 1))     
+        DZPushPendingRecord(DZGetCurrentState(), DZMakeActionData(1))     
     end 
 }
 
@@ -242,39 +143,18 @@ OnWeaponFired { "ShieldWeaponRush",
             return false
         end
 
-        local duration = 0.0
-        if DZTemp.ChargeWeapon == "Attack" then
-            duration = _worldTime - DZTemp.StartChargingTime 
-        end
-
-        DZOverridePendingRecord(DZGetCurrentState(), DZMakeActionData(1, duration, 1.6))     
+        DZOverridePendingRecord(DZGetCurrentState(), DZMakeActionData(4))     
     end 
 }
 
 DZTemp.ShieldThrowed = false
-OnWeaponCharging { "ShieldThrow ShieldThrowDash",
-    function(triggerArgs)
-        if not DZCheckCanRecord() then
-            return false
-        end
-
-        DZTemp.ChargeWeapon = "SpecialAttack"
-        DZTemp.StartChargingTime = _worldTime
-    end 
-}
-
 OnWeaponFired { "ShieldThrow ShieldThrowDash",
     function( triggerArgs )
         if not DZCheckCanRecord() then
             return false
         end
 
-        local duration = 0.0
-        if DZTemp.ChargeWeapon == "SpecialAttack" then
-            duration = _worldTime - DZTemp.StartChargingTime 
-        end
-
-        DZPushPendingRecord(DZGetCurrentState(), DZMakeActionData(2, duration, 1))
+        DZPushPendingRecord(DZGetCurrentState(), DZMakeActionData(2))
 
         if DZTemp.ShieldThrowed == false then
             DZTemp.ShieldThrowed = true 
@@ -282,6 +162,7 @@ OnWeaponFired { "ShieldThrow ShieldThrowDash",
     end
 }
 
+-- handle aspecot of zeus
 OnWeaponFailedToFire { "ShieldThrow",
     function( triggerArgs )
         if not DZCheckCanRecord() then
@@ -296,8 +177,7 @@ OnWeaponFailedToFire { "ShieldThrow",
 		local weaponData = GetWeaponData( attacker, triggerArgs.name )
 
         if weaponData.RecallOnFailToFire then
-            -- DebugPrint({ Text = "ShieldThrow" })
-            DZPushPendingRecord(DZGetCurrentState(), DZMakeActionData(2, 0, 1))
+            DZPushPendingRecord(DZGetCurrentState(), DZMakeActionData(2))
 
             DZTemp.ShieldThrowed = false
         end
@@ -312,102 +192,40 @@ OnWeaponFailedToFire { "ShieldThrow",
 -- if I just record the action with OnControlPressed and OnControlReleased,
 -- it is not secured that the weapon is fired, sometimes it will wrongly add redundant data into the record
 -- so I decide to just record it with OnWeaponFired, which is easier 
-OnWeaponCharging { "FistWeapon FistWeapon2 FistWeapon3 FistWeapon4 FistWeapon5 FistWeaponDash",
-    function(triggerArgs)
-        if not DZCheckCanRecord() then
-            return false
-        end
-
-        DZTemp.ChargeWeapon = "Attack"
-        DZTemp.StartChargingTime = _worldTime
-    end 
-}
-
 OnWeaponFired { "FistWeapon FistWeapon2 FistWeapon3 FistWeapon4 FistWeapon5 FistWeaponDash",
     function(triggerArgs)
         if not DZCheckCanRecord() then
             return false
         end
 
-        local duration = 0.0
-        if DZTemp.ChargeWeapon == "Attack" then
-            duration = _worldTime - DZTemp.StartChargingTime 
-        end
-
-        DZPushPendingRecord(DZGetCurrentState(), DZMakeActionData(1, duration, 1))     
+        DZPushPendingRecord(DZGetCurrentState(), DZMakeActionData(1))     
     end 
 }
 
 -- ignore Flying Cutter and Kinetic Launcher, which is chargable special
 -- just treat it as normal special
-OnWeaponCharging { "FistWeaponSpecial FistWeaponSpecialDash",
-    function(triggerArgs)
-        if not DZCheckCanRecord() then
-            return false
-        end
-        
-        DZTemp.ChargeWeapon = "SpecialAttack"
-        DZTemp.StartChargingTime = _worldTime
-    end 
-}
-
 OnWeaponFired { "FistWeaponSpecial FistWeaponSpecialDash",
     function(triggerArgs)
         if not DZCheckCanRecord() then
             return false
         end
 
-        local duration = 0.0
-        if DZTemp.ChargeWeapon == "SpecialAttack" then
-            duration = _worldTime - DZTemp.StartChargingTime 
-        end
-
-        -- DebugPrint({ Text = "FistWeaponSpecial" })
-        DZPushPendingRecord(DZGetCurrentState(), DZMakeActionData(2, duration, 1))     
+        DZPushPendingRecord(DZGetCurrentState(), DZMakeActionData(2))     
     end 
 }
 
 -- gun
 -- same as fist weapon
-
 -- ignore the bias affected by Delta Chamber, let it be
-OnWeaponCharging { "GunWeapon GunWeaponDash SniperGunWeapon SniperGunWeaponDash",
-    function(triggerArgs)
-        if not DZCheckCanRecord() then
-            return false
-        end
-
-        DZTemp.ChargeWeapon = "Attack"
-        DZTemp.StartChargingTime = _worldTime
-    end 
-}
-
 OnWeaponFired { "GunWeapon GunWeaponDash SniperGunWeapon SniperGunWeaponDash",
     function(triggerArgs)
         if not DZCheckCanRecord() then
             return false
         end
-        local duration = 0.0
-        if DZTemp.ChargeWeapon == "Attack" then
-            duration = _worldTime - DZTemp.StartChargingTime 
-        end
 
-        -- DebugPrint({ Text = "GunWeapon" })
-        DZPushPendingRecord(DZGetCurrentState(), DZMakeActionData(1, duration, 1))     
+        DZPushPendingRecord(DZGetCurrentState(), DZMakeActionData(1))     
     end 
 }
-
-OnWeaponCharging { "FistWeaponSpecial FistWeaponSpecialDash",
-    function(triggerArgs)
-        if not DZCheckCanRecord() then
-            return false
-        end
-        
-        DZTemp.ChargeWeapon = "SpecialAttack"
-        DZTemp.StartChargingTime = _worldTime
-    end 
-}
-
 
 OnWeaponFired { "GunGrenadeToss",
     function(triggerArgs)
@@ -415,12 +233,7 @@ OnWeaponFired { "GunGrenadeToss",
             return false
         end
 
-        local duration = 0.0
-        if DZTemp.ChargeWeapon == "SpecialAttack" then
-            duration = _worldTime - DZTemp.StartChargingTime 
-        end
-
-        DZPushPendingRecord(DZGetCurrentState(), DZMakeActionData(1, duration, 1))     
+        DZPushPendingRecord(DZGetCurrentState(), DZMakeActionData(1))     
     end 
 }
 
@@ -439,6 +252,6 @@ OnWeaponFired{ "RushWeapon",
         local action = (math.abs(angle - angleBetween) > 90) and 3 or 0
         -- this way might miss catch back dash(aiming front but dash back, not sure how to solve it)
         -- dash away or dash toward
-        DZPushPendingRecord(DZGetCurrentState(), DZMakeActionData(action, 0.0, 1))
+        DZPushPendingRecord(DZGetCurrentState(), DZMakeActionData(action))
     end
 } 

--- a/Scripts/RecordScripts.lua
+++ b/Scripts/RecordScripts.lua
@@ -177,12 +177,12 @@ end
 DZLogRecord = function (state, action) 
     DZDebugPrintString(string.format("%.2f %.2f %.2f %.2f %.2f %.2f %.2f %.2f %.2f %.2f %.2f", 
         state.OwnHP, state.ClosestEnemyHP, state.Distance, state.GetDamagedRecently, state.DamageEnemyRecently, state.MarkTargetRecently,
-        action.DashToward, action.Attack, action.SpecialAttack, action.DashAway, action.SpecialAttack))
+        action.DashToward, action.Attack, action.SpecialAttack, action.DashAway, action.ChargeAttack))
 
     table.insert(DZPersistent.CurRunRecord.History, 
     {
       { state.OwnHP, state.ClosestEnemyHP, state.Distance, state.GetDamagedRecently, state.DamageEnemyRecently, state.MarkTargetRecently },
-      { action.DashToward, action.Attack, action.SpecialAttack, action.DashAway ,action.SpecialAttack }
+      { action.DashToward, action.Attack, action.SpecialAttack, action.DashAway ,action.ChargeAttack }
     })
 end
 

--- a/Scripts/RecordScripts.lua
+++ b/Scripts/RecordScripts.lua
@@ -39,23 +39,20 @@ function DZCheckCanRecord()
     return true
 end
 
-function DZMakeActionData(action, chargeTime, maxChargeTime)
+function DZMakeActionData(action)
     local dashToward = (action == 0) and 1.0 or 0.0
     local attack = (action == 1) and 1.0 or 0.0
     local special = (action == 2) and 1.0 or 0.0
     local dashAway = (action == 3) and 1.0 or 0.0 -- added in v2
-    -- 0 DashToward, 1 Attack, 2 Special Attack, 3 DashAway
-
-    local time = chargeTime / maxChargeTime
-    time = (time > 1.0) and 1.0 or time -- if exceed 1 then clamp to 1
-    time = (time < 0.0) and 0.0 or time -- if less than 0 clamp to 0, usually not happens
+    local chargeAttack = (action == 4) and 1.0 or 0.0 -- added in v5
+    -- 0 DashToward, 1 Attack, 2 Special Attack, 3 DashAway, 4 Charge Attack
 
     return {    
         DashToward = dashToward,
         DashAway = dashAway,
         Attack = attack,
         SpecialAttack = special,
-        ChargeTime = time
+        ChargeAttack = chargeAttack 
     }
 end
 
@@ -180,12 +177,12 @@ end
 DZLogRecord = function (state, action) 
     DZDebugPrintString(string.format("%.2f %.2f %.2f %.2f %.2f %.2f %.2f %.2f %.2f %.2f %.2f", 
         state.OwnHP, state.ClosestEnemyHP, state.Distance, state.GetDamagedRecently, state.DamageEnemyRecently, state.MarkTargetRecently,
-        action.DashToward, action.Attack, action.SpecialAttack, action.DashAway, action.ChargeTime))
+        action.DashToward, action.Attack, action.SpecialAttack, action.DashAway, action.SpecialAttack))
 
     table.insert(DZPersistent.CurRunRecord.History, 
     {
       { state.OwnHP, state.ClosestEnemyHP, state.Distance, state.GetDamagedRecently, state.DamageEnemyRecently, state.MarkTargetRecently },
-      { action.DashToward, action.Attack, action.SpecialAttack, action.DashAway ,action.ChargeTime }
+      { action.DashToward, action.Attack, action.SpecialAttack, action.DashAway ,action.SpecialAttack }
     })
 end
 

--- a/Scripts/TrainingScripts.lua
+++ b/Scripts/TrainingScripts.lua
@@ -7,13 +7,13 @@ function DZTrainAI()
         return
     end
 
-    local learningRate = 1 -- set between 1, 100
-    local epoch = 1 -- number of times to do backpropagation
+    local learningRate = 3 -- set between 1, 100
+    local epoch = 10 -- number of times to do backpropagation
     local threshold = 1 -- steepness of the sigmoid curve
 
     -- Input: PlayerHP, ClosetEnemyHP, ClosetEnemyDistance, IsLastActionDash, IsLastActionAttack, IsLastActionSpecialAttack
     -- Output: DashProb, AttackProb, SpecialAttackProb, ChargeTime
-    local network = Luann:new({11, 8, 8, 5}, learningRate, threshold)
+    local network = Luann:new({16, 11, 11, 5}, learningRate, threshold)
 
     if DZPersistent.PrevRunRecord == nil then
         DZDebugPrintString("DZTrainAI() - PrevRunRecord is missing")
@@ -26,13 +26,15 @@ function DZTrainAI()
     end
 
     local dataset = DeepCopyTable(DZPersistent.PrevRunRecord.History)
-
+    local consideration = 1 -- conside how many past actions, 2 means 2 past actions
     -- insert last actions to each data, this provides more information for training the model
-    for i = 2, #dataset do
-        local prev = dataset[i - 1][2]
-
-        for j = 1, #prev do
-            table.insert(dataset[i][1], prev[j])
+    for i = 1 + consideration, #dataset do
+        for j = 1, consideration do
+            local prev = dataset[i - j][2]    
+            
+            for k = 1, #prev do
+                table.insert(dataset[i][1], prev[k])
+            end
         end
     end
 

--- a/config.lua
+++ b/config.lua
@@ -4,23 +4,25 @@ DarkZagreus.Config = {
 }
 
 DarkZagreus.Version = "beta1.2"
-DarkZagreus.DataVersion = "v4" -- for training data, when the data structure chages, the version increases
+DarkZagreus.DataVersion = "v5" -- for training data, when the data structure chages, the version increases
 
 -- State Scheme
 -- {
 --     OwnHP,
 --     ClosestEnemyHP,
 --     Distance,
---     GetDamagedRecently,
---     DamageEnemyRecently,
---     MarkTargetRecently
+--     GetDamagedRecently, -- added in v3
+--     DamageEnemyRecently, -- added in v3
+--     MarkTargetRecently -- added in v4
 -- }
 
 -- Action Scheme
 -- {    
 --     DashToward,
---     DashAway,
 --     Attack,
 --     SpecialAttack,
---     ChargeTime
+--     DashAway, -- added in v2
+--     ChargeTime -- deprecated in v5
+--     ChargeAttack, -- added in v5, for weapons like spear or shield,
+--                      whcih have a additional charge attack from the attack action
 -- }


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring
- [ ] Optimization

# Description

- Bow, spear, and shield weapons couldn't charge properly due to model training issues. It is a long discussion. In short, many weapons like dash and non-charge attacks produce a charge time of 0.0 in the record while charge attacks have their own charge time. Therefore, most of the predictions will close to 0.0, which means charge weapons are always fail to fire (minimum charge time is 0.3)
- Update data version to v5, remove charge time in action, and add charge attack as a new move, distinguishing from primary attack