### PR TITLE
Feature/fix spear dash charge attack issue

### DIFF
--- a/DarkZagreus/Weapons/Spears/AspectofAchilles.lua
+++ b/DarkZagreus/Weapons/Spears/AspectofAchilles.lua
@@ -156,7 +156,14 @@ WeaponData.DarkAchillesSpearDash =
 			AIAngleTowardsPlayerWhileFiring = true,
 			AITrackTargetDuringCharge = true,
 			AIMoveWithinRangeTimeout = 1.0,
-			FireDuration = 0.425,
+			FireDuration = 0.15,
+			PostFireChargeStages = 
+			{
+				{ ChargeWeapon = "DarkAchillesSpearSpin", Threshold = 0.6 },
+				{ ChargeWeapon = "DarkAchillesSpearSpin2", Threshold = 0.93 },
+				{ ChargeWeapon = "DarkAchillesSpearSpin3", Threshold = 1.66 },
+			},
+			MaxChargeTime = 1.7
 		},
 
 		Sounds =
@@ -289,7 +296,7 @@ WeaponData.DarkAchillesSpearSpin =
 
 		AIData =
 		{
-			FireDuration = 0.4,
+			FireDuration = 0.15,
 			AIAngleTowardsPlayerWhileFiring = true,
 			AITrackTargetDuringCharge = true,
 			AIMoveWithinRangeTimeout = 1.0,

--- a/DarkZagreus/Weapons/Spears/AspectofGuanYu.lua
+++ b/DarkZagreus/Weapons/Spears/AspectofGuanYu.lua
@@ -160,7 +160,14 @@ WeaponData.DarkGuanYuSpearDash =
 			AIAngleTowardsPlayerWhileFiring = true,
 			AITrackTargetDuringCharge = true,
 			AIMoveWithinRangeTimeout = 1.0,
-			FireDuration = 0.425,
+			FireDuration = 0.15,
+			PostFireChargeStages = 
+			{
+				{ ChargeWeapon = "DarkGuanYuSpearSpin", Threshold = 0.6 },
+				{ ChargeWeapon = "DarkGuanYuSpearSpin2", Threshold = 0.93 },
+				{ ChargeWeapon = "DarkGuanYuSpearSpin3", Threshold = 1.66 },
+			},
+			MaxChargeTime = 1.7
 		},
 
 		Sounds =
@@ -250,7 +257,7 @@ WeaponData.DarkGuanYuSpearSpin =
 
 		AIData =
 		{
-			FireDuration = 0.4,
+			FireDuration = 0.15,
 			AIAngleTowardsPlayerWhileFiring = true,
 			AITrackTargetDuringCharge = true,
 			AIMoveWithinRangeTimeout = 1.0,

--- a/DarkZagreus/Weapons/Spears/AspectofHades.lua
+++ b/DarkZagreus/Weapons/Spears/AspectofHades.lua
@@ -112,7 +112,7 @@ WeaponData.DarkHadesSpear3 =
 			SkipMovement = true,
 			AIAngleTowardsPlayerWhileFiring = true,
 			AITrackTargetDuringCharge = true,
-			FireDuration = 0.05,
+			FireDuration = 0.07,
 			PostFireChargeStages = 
 			{
 				{ ChargeWeapon = "DarkHadesSpear2", Threshold = 0.60 },
@@ -154,7 +154,13 @@ WeaponData.DarkHadesSpearDash =
 			SkipMovement = true,
 			AIAngleTowardsPlayerWhileFiring = true,
 			AITrackTargetDuringCharge = true,
-			FireDuration = 0.425,
+			FireDuration = 0.15,
+			PostFireChargeStages = 
+			{
+				{ ChargeWeapon = "DarkHadesSpear2", Threshold = 0.60 },
+				{ ChargeWeapon = "DarkHadesSpear3", Threshold = 0.90 },
+			},
+			MaxChargeTime = 1
 		},
 
 		Sounds =
@@ -286,7 +292,7 @@ WeaponData.DarkHadesSpearSpin =
 
 		AIData =
 		{
-			FireDuration = 0.4,
+			FireDuration = 0.15,
 			AIAngleTowardsPlayerWhileFiring = true,
 			AITrackTargetDuringCharge = true,
 			AIMoveWithinRangeTimeout = 1.0,

--- a/DarkZagreus/Weapons/Spears/SpearWeapon.lua
+++ b/DarkZagreus/Weapons/Spears/SpearWeapon.lua
@@ -155,7 +155,13 @@ WeaponData.DarkSpearDash =
 			SkipMovement = true,
 			AIAngleTowardsPlayerWhileFiring = true,
 			AITrackTargetDuringCharge = true,
-			FireDuration = 0.425
+			FireDuration = 0.15,
+			{
+				{ ChargeWeapon = "DarkSpearSpin", Threshold = 0.6 },
+				{ ChargeWeapon = "DarkSpearSpin2", Threshold = 0.93 },
+				{ ChargeWeapon = "DarkSpearSpin3", Threshold = 1.66 },
+			},
+			MaxChargeTime = 1.7
 		},
 
 		Sounds =
@@ -287,7 +293,7 @@ WeaponData.DarkSpearSpin =
 
 		AIData =
 		{
-			FireDuration = 0.4,
+			FireDuration = 0.15,
 			AIAngleTowardsPlayerWhileFiring = true,
 			AITrackTargetDuringCharge = true,
 			AIMoveWithinRangeTimeout = 1.0,

--- a/Scripts/EnemyAI.lua
+++ b/Scripts/EnemyAI.lua
@@ -195,8 +195,10 @@ function DZAIMakeActionData(state, lastActions)
     end
 
     if DZTemp.Model == nil or #DZTemp.Model == 0 or #lastActions < consideration then
-        DZDebugPrintString("Model is not available, make random data.")
-        return DZAIMakeRandomActionData(state)
+        if DarkZagreus.EnableAILog then
+            DZDebugPrintString("Model is not available, make random data.")
+        end
+            return DZAIMakeRandomActionData(state)
     end
 
     local input = {

--- a/Scripts/EnemySpearAI.lua
+++ b/Scripts/EnemySpearAI.lua
@@ -120,7 +120,6 @@ function DZAIFireSpearWeapon(enemy, weaponAIData, currentRun, targetId, actionDa
 
     if weaponAIData.PostFireChargeStages ~= nil then
         chargeTime = percentageCharged * weaponAIData.MaxChargeTime
-        DebugPrintf({ Text = "Set chargeTime to " .. chargeTime})
     end
 
     if ReachedAIStageEnd(enemy) or currentRun.CurrentRoom.InStageTransition then


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring
- [ ] Optimization

# Description

Spear dash does not perform charge attack(spin), even if the charge time is set over 0.3, this is because I forgot to put post attack settings in the spear dash AI data.